### PR TITLE
Remove leading space in LATESTCOMIC template?

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ async function createNewExplanation(info) {
     log("[INFO] - Updating latest comic");
     await bot.edit(
       "Template:LATESTCOMIC",
-      `<noinclude>The latest [[xkcd]] comic is number:</noinclude> ${comicNum}`,
+      `<noinclude>The latest [[xkcd]] comic is number: </noinclude>${comicNum}`,
       CHANGE_SUMMARY
     );
 


### PR DESCRIPTION
Hey theusaf! I noticed that the LATESTCOMIC template returns, for example, " 2819" instead of "2819" (with a leading space). I'm not sure if the leading space is required, but if it's not, could it be removed? It messes the "List of comics" template and I think it's unintuitive: one would expect a template like that to return a single number. Thanks!